### PR TITLE
Strip dollar sign from price when parsing single result

### DIFF
--- a/recherche_babac2/recherche_babac2.py
+++ b/recherche_babac2/recherche_babac2.py
@@ -194,6 +194,8 @@ def parse_single_result(
         )[1].text
         item_price = re.findall(price_pattern, item_price)[0]
 
+    item_price = item_price.strip('$')
+
     is_instock = (
         soup_results.find("span", {"class": "stock_wrapper"})
         .span.text.lstrip()


### PR DESCRIPTION
When a search returns a single result, there is an extra dollar sign in
the price:

    | 36-817 | Tektro V-brake lever MT20                     |   $16.00$ | Yes       |

This is because the library returns a price string with a dollar sign
when the search yields a single result, but without dollar sign when
the search yields multiple results.

The function `parse_info` already strips the dollar sign, so make
`parse_single_result` strip it as well, such that prices as consistently
returned in the `AA.BB` format.

With this change, the command-line displays the price correctly:

    | 36-817 | Tektro V-brake lever MT20                     |    16.00$ | Yes       |